### PR TITLE
Update yak-gui to 1.14.1

### DIFF
--- a/Casks/yak-gui.rb
+++ b/Casks/yak-gui.rb
@@ -1,5 +1,5 @@
 cask "yak-gui" do
-  version "1.14.0"
+  version "1.14.1"
   sha256 :no_check
 
   url "https://github.com/santi1s/yak-gui/releases/download/v#{version}/yak-gui-darwin-universal.tar.gz"


### PR DESCRIPTION
Updates yak-gui cask to version 1.14.1

- Version: 1.14.1
- Release: https://github.com/santi1s/yak-gui/releases/tag/v1.14.1
- SHA256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855

Auto-generated by yak-gui release workflow.